### PR TITLE
fix(pwa): improve offline functionality with better caching strategy

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -112,6 +112,8 @@ export default defineNuxtConfig({
       navigateFallback: '/', // Fallback page for offline navigation
       globPatterns: ['**/*.{js,css,html,png,svg,ico,woff,woff2}'], // Files to cache
       maximumFileSizeToCacheInBytes: 3 * 1024 * 1024, // 3MB limit to handle large script files
+      cleanupOutdatedCaches: true, // Remove old caches automatically
+      clientsClaim: true, // Take control of pages immediately on activation
       runtimeCaching: [
         {
           urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
@@ -153,5 +155,11 @@ export default defineNuxtConfig({
       navigateFallbackAllowlist: [/^\/$/],
       type: 'module'
     }
-  }
+  },
+  // Prerender the homepage for offline support
+  nitro: {
+    prerender: {
+      routes: ['/'],
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- Improved PWA offline support by adding better caching configuration
- Added nitro prerender for homepage to ensure offline availability

## Changes
- Add `cleanupOutdatedCaches: true` to workbox config for automatic old cache removal
- Add `clientsClaim: true` for immediate service worker activation  
- Add nitro prerender configuration to pre-generate homepage for offline access

## Test plan
- [x] Build the app with `bun run build`
- [x] Run preview server with `bun run preview`
- [x] Visit the app and install it as PWA
- [x] Go offline (airplane mode or disable network)
- [x] Refresh the page - it should still load properly
- [x] Navigation should work offline

This fixes the issue where the PWA would show "No Internet" page when offline and refreshed.