### PR TITLE
Fix auto-save reuse

### DIFF
--- a/app/composables/useMarkdownEditor.ts
+++ b/app/composables/useMarkdownEditor.ts
@@ -24,14 +24,15 @@ export function useMarkdownEditor() {
   
   // Set up auto-save
   const { 
-    setupAutoSave, 
+    setupAutoSave,
     getRecoverableContent,
     saveStatus,
     saveError,
     lastSaveTimeAgo,
     hasUnsavedChanges,
     saveNow,
-    saveStats
+    saveStats,
+    clearSavedContent
   } = useAutoSave()
   
   // Recovery state
@@ -64,7 +65,6 @@ export function useMarkdownEditor() {
   const discardRecovery = () => {
     showRecoveryPrompt.value = false
     recoverableContent.value = null
-    const { clearSavedContent } = useAutoSave()
     clearSavedContent()
   }
   
@@ -254,6 +254,7 @@ export function useMarkdownEditor() {
     saveNow,
     recoverContent,
     discardRecovery,
+    clearSavedContent,
     toggleTask,
     taskItems
   }

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -385,6 +385,7 @@ const {
   saveNow,
   recoverContent,
   discardRecovery,
+  clearSavedContent,
   toggleTask
 } = useMarkdownEditor()
 
@@ -458,7 +459,6 @@ const clearEditor = () => {
   // Clear saved content after a delay to prevent recovery prompt
   setTimeout(() => {
     if (!markdownInput.value && !showClearUndo.value) {
-      const { clearSavedContent } = useAutoSave()
       clearSavedContent()
     }
   }, 15000) // 15 seconds - longer than undo timeout


### PR DESCRIPTION
## Summary
- reuse auto-save composable instead of creating a new instance

## Testing
- `bun run typecheck`
- `bun run build` *(fails: fetch failed for mermaid)*

------
https://chatgpt.com/codex/tasks/task_e_684417b8aa3483329a0c62269bfa0549